### PR TITLE
A small change to Record.UPDATE

### DIFF
--- a/circumflex-orm/src/main/scala/record.scala
+++ b/circumflex-orm/src/main/scala/record.scala
@@ -128,6 +128,8 @@ abstract class Record[PK, R <: Record[PK, R]] extends Equals { this: R =>
     if (relation.autorefresh_?) refresh()
     // Invalidate caches
     contextCache.evictInverse[PK, R](this)
+    contextCache.evictRecord(PRIMARY_KEY(), relation)
+    contextCache.cacheRecord(PRIMARY_KEY(), relation, Some(this))
     // Execute events
     relation.afterUpdate.foreach(c => c(this))
     return result


### PR DESCRIPTION
Hi. First, thanks for your efforts on a really amazing framework. 

Our ORM layer has some logic to merge incoming data with what is already in the database, at the record level. We realized that having two different instances pointing to the same row could cause some cache confusion. I am hoping that you will consider this very small change. Below is the commit message.

Thanks,
Scott

Added lines to evict a record from the normal context cache on UPDATE, then add it again.

This solves a problem with two separate instances of the same record which share a PK.
When the second instance was saved, it would not update the contextCache. This would cause
subsequent queries for the record with that PK to refer to the values in the first
instance.
